### PR TITLE
Fix dispatcher usage for thread-safe UI updates

### DIFF
--- a/PhotoFromScreensaver/ViewModels/MyWindowsViewModel.cs
+++ b/PhotoFromScreensaver/ViewModels/MyWindowsViewModel.cs
@@ -376,10 +376,10 @@ namespace PhotoFromScreensaver.ViewModels
             get => _OutputForWin;
             set
             {
-                if (Dispatcher.CurrentDispatcher.CheckAccess())
+                if (App.Current.Dispatcher.CheckAccess())
                     Set(ref _OutputForWin, String.Concat(_OutputForWin, "\n", value));
                 else
-                    Dispatcher.CurrentDispatcher.Invoke(() =>
+                    App.Current.Dispatcher.Invoke(() =>
                         Set(ref _OutputForWin, String.Concat(_OutputForWin, "\n", value)));
             }
         }


### PR DESCRIPTION
## Summary
- fix UI update logic to use the application's dispatcher

## Testing
- `dotnet test` *(fails: `dotnet` not found)*